### PR TITLE
Support Xcode8 with Swift2.3

### DIFF
--- a/sample/SNDraw/SNDraw.xcodeproj/project.pbxproj
+++ b/sample/SNDraw/SNDraw.xcodeproj/project.pbxproj
@@ -169,6 +169,7 @@
 				TargetAttributes = {
 					740A41291D50AA9F006F446E = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0800;
 					};
 					7458533A1D55E34800CDE58D = {
 						CreatedOnToolsVersion = 7.3.1;
@@ -321,6 +322,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 2.3;
 			};
 			name = Debug;
 		};
@@ -358,6 +360,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/sample/SNDraw/SNDraw.xcodeproj/project.pbxproj
+++ b/sample/SNDraw/SNDraw.xcodeproj/project.pbxproj
@@ -164,7 +164,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = "Satoshi Nakajima";
 				TargetAttributes = {
 					740A41291D50AA9F006F446E = {
@@ -294,8 +294,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -340,8 +342,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -360,6 +364,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 2.3;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -439,6 +444,7 @@
 				7458534C1D55E34800CDE58D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/src/SNPathBuilder.swift
+++ b/src/SNPathBuilder.swift
@@ -60,10 +60,13 @@ public struct SNPathBuilder {
             length = 0.0
         } else {
             // Neigher. Return the path with a line to the current point as a transient path.
-            let pathTemp = CGPathCreateMutableCopy(path)
-            CGPathAddLineToPoint(pathTemp, nil, pt.x, pt.y)
-            pathToReturn = pathTemp
-            delta = pt.delta(anchor)
+            if let pathTemp = CGPathCreateMutableCopy(path) {
+                CGPathAddLineToPoint(pathTemp, nil, pt.x, pt.y)
+                pathToReturn = pathTemp
+                delta = pt.delta(anchor)
+            } else {
+                assertionFailure("SNPathBuilder: CGPathCreateMutableCopy should not fail.")
+            }
         }
         last = pt
         


### PR DESCRIPTION
Updated the project settings to support Xcode 8.

Only a part of the source code was modified because of change of CGPathCreateMutableCopy API. Its returned value has been changed to an optional value. I added an assertion for the case when `nil` is returned (291fb6b), because the case is not documented and it looks `nil` is never returned actually.
