### PR TITLE
Swift 4.2 migration

### DIFF
--- a/sample/SNDraw/SNDraw.xcodeproj/project.pbxproj
+++ b/sample/SNDraw/SNDraw.xcodeproj/project.pbxproj
@@ -173,7 +173,7 @@
 					};
 					7458533A1D55E34800CDE58D = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0800;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -423,6 +423,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudreaders.SNDraw2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -434,6 +436,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cloudreaders.SNDraw2;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/sample/SNDraw/SNDraw/ViewController.swift
+++ b/sample/SNDraw/SNDraw/ViewController.swift
@@ -53,8 +53,8 @@ extension ViewController : SNDrawViewDelegate {
         layerCurve.lineWidth = 12
         layerCurve.fillColor = UIColor.clear.cgColor
         layerCurve.strokeColor = UIColor(red: 0, green: 1, blue: 0, alpha: 0.4).cgColor
-        layerCurve.lineCap = convertToCAShapeLayerLineCap("round")
-        layerCurve.lineJoin = convertToCAShapeLayerLineJoin("round")
+        layerCurve.lineCap = CAShapeLayerLineCap(rawValue: "round")
+        layerCurve.lineJoin = CAShapeLayerLineJoin(rawValue: "round")
         self.view.layer.addSublayer(layerCurve)
         layers.append(layerCurve)
 
@@ -70,15 +70,4 @@ extension ViewController : SNDrawViewDelegate {
 
         return true
     }
-}
-
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToCAShapeLayerLineCap(_ input: String) -> CAShapeLayerLineCap {
-	return CAShapeLayerLineCap(rawValue: input)
-}
-
-// Helper function inserted by Swift 4.2 migrator.
-fileprivate func convertToCAShapeLayerLineJoin(_ input: String) -> CAShapeLayerLineJoin {
-	return CAShapeLayerLineJoin(rawValue: input)
 }

--- a/sample/SNDraw/SNDraw2/AppDelegate.swift
+++ b/sample/SNDraw/SNDraw2/AppDelegate.swift
@@ -14,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }

--- a/sample/SNDraw/SNDraw2/ViewController.swift
+++ b/sample/SNDraw/SNDraw2/ViewController.swift
@@ -84,8 +84,8 @@ class ViewController: UIViewController {
         shapeLayer.contentsScale = UIScreen.main.scale
         shapeLayer.lineWidth = 10.0
         shapeLayer.strokeColor = UIColor(red: 0, green: 0, blue: 1, alpha: 0.3).cgColor
-        shapeLayer.lineCap = kCALineCapRound
-        shapeLayer.lineJoin = kCALineJoinRound
+        shapeLayer.lineCap = CAShapeLayerLineCap.round
+        shapeLayer.lineJoin = CAShapeLayerLineJoin.round
         shapeLayer.fillColor = UIColor.clear.cgColor
         self.view.layer.addSublayer(shapeLayer)
         return shapeLayer


### PR DESCRIPTION
- Remove  Helper functions inserted by Swift 4.2 migrator.
- Migrate to Swift 4.2 and deleted SNDraw 2 warning.

Best Regards.